### PR TITLE
Add function to check if native barcode reader is available.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emisys/audience-pos-hardware-interface",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Provide the global variable injected in the Point of Sale website by the native wrapper application",
   "repository": "https://github.com/Emisys/audience-pos-hardware-interface.git",
   "homepage": "https://github.com/Emisys/audience-pos-hardware-interface",

--- a/posapp_emisys/EmisysCamera.d.ts
+++ b/posapp_emisys/EmisysCamera.d.ts
@@ -1,5 +1,12 @@
 export default class EmisysCamera {
   /**
+   * Is the device equiped with a barcode scanner?
+   * Note that this is the react-native camera. The webview may still offer its
+   * own navigator.mediaDevices.enumerateDevices().
+   */
+  hasBarcodeScanner(): boolean;
+
+  /**
    * Open barcode scanner
    */
   openBarcodeScanner(): void;


### PR DESCRIPTION
Expose la fonction `emisys.camera.hasBarcodeScanner()`.

Version 1.0.31.